### PR TITLE
Fix disconnect() does not always resolve

### DIFF
--- a/packages/imap-emails/src/lib/imap-emails.ts
+++ b/packages/imap-emails/src/lib/imap-emails.ts
@@ -93,7 +93,7 @@ export class ImapEmails {
 
   public disconnect(): Promise<void> {
     return new Promise<void>((resolve) => {
-      this.imap.once('end', () => {
+      this.imap.once('close', () => {
         resolve();
       });
 


### PR DESCRIPTION
Hi! 👋 
      
Firstly, thanks for your work on this project! 🙂

I'm using `imap-emails@1.0.4` but I ran into a problem where `disconnect()` did never resolve. After some research I stumbled upon [this comment](https://github.com/mscdex/node-imap/issues/394#issuecomment-45215184) by the imap maintainer that claims that you should rather use `"close"` instead of `"end"` to wait for the socket to be terminated.

This fix solved my issue with `disconnect()` :)